### PR TITLE
Only add tool cache Python to PATH if no `pythonLocation` specified

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -5652,7 +5652,7 @@ async function innerMain() {
         exitCode = await dockerBuild(tag, args);
     }
     else {
-        if (IS_MACOS) {
+        if (IS_MACOS && !process.env.pythonLocation) {
             addToolCachePythonVersionsToPath();
         }
         core.startGroup('Install maturin');

--- a/src/index.ts
+++ b/src/index.ts
@@ -402,7 +402,7 @@ async function innerMain(): Promise<void> {
   if (useDocker) {
     exitCode = await dockerBuild(tag, args)
   } else {
-    if (IS_MACOS) {
+    if (IS_MACOS && !process.env.pythonLocation) {
       addToolCachePythonVersionsToPath()
     }
 


### PR DESCRIPTION
Fixes https://github.com/messense/maturin-action/issues/15#issuecomment-969833111