### PR TITLE
Do not attempt to pull local images

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -219,13 +219,15 @@ async function dockerBuild(tag: string, args: string[]): Promise<number> {
     dockerArgs.push('--entrypoint', '/bin/bash')
   }
 
-  core.startGroup('Pull Docker image')
-  core.info(`Using ${image} Docker image`)
-  const exitCode = await exec.exec('docker', ['pull', image])
-  if (exitCode !== 0) {
-    throw new Error(`maturin: 'docker pull' returned ${exitCode}`)
+  if (container.includes('/')) {
+    core.startGroup('Pull Docker image')
+    core.info(`Using ${image} Docker image`)
+    const exitCode = await exec.exec('docker', ['pull', image])
+    if (exitCode !== 0) {
+      throw new Error(`maturin: 'docker pull' returned ${exitCode}`)
+    }
+    core.endGroup()
   }
-  core.endGroup()
 
   const arch = process.arch === 'arm64' ? 'aarch64' : 'x86_64'
   const url =


### PR DESCRIPTION
Allows to use a local Docker image for base (identified by not having a "/" in their name).

It is useful to install in the build docker container packages useful for build (like libclang to generate bindings using bindgen).