### PR TITLE
Add alias for riscv on manylinux

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -33193,6 +33193,7 @@ const TARGET_ALIASES = {
         armv7l: 'armv7-unknown-linux-gnueabihf',
         ppc64le: 'powerpc64le-unknown-linux-gnu',
         ppc64: 'powerpc64-unknown-linux-gnu',
+        riscv64: 'riscv64gc-unknown-linux-gnu',
         s390x: 's390x-unknown-linux-gnu'
     },
     musllinux: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -224,6 +224,7 @@ const TARGET_ALIASES: Record<string, Record<string, string>> = {
     armv7l: 'armv7-unknown-linux-gnueabihf',
     ppc64le: 'powerpc64le-unknown-linux-gnu',
     ppc64: 'powerpc64-unknown-linux-gnu',
+    riscv64: 'riscv64gc-unknown-linux-gnu',
     s390x: 's390x-unknown-linux-gnu'
   },
   musllinux: {


### PR DESCRIPTION
With more Python packages starting to offer wheels for riscv64, I thought it would be nice to also offer an alias for the architecture when building wheels using Maturin in a GitHub action.

Musllinux support seems to be in progress still, so I did not add an alias for that yet.

I already tested [building pydantic](https://github.com/boosterl/pydantic-core/actions/runs/20963198023/job/60245951764) for manylinux riscv64 without the alias using the Maturin action, which worked without an issue! Adding the alias would add some consistency in workflows.